### PR TITLE
cleaned up hard-coded variables and fixed push to mongodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# mac stuff
+.DS_Store

--- a/stacks_core/mongo_loader.py
+++ b/stacks_core/mongo_loader.py
@@ -27,9 +27,6 @@ def initialize_info_logger(log_config):
 def push_rows(CTX, rows):
     info_logger = logging.getLogger('Info_Logger')
 
-    server_url = 'mongodb://%s:%s@perseus.ischool.syr.edu'
-    dbase='Stacks'
-
     db_config = CTX["persistance"]
 
     server_name = db_config["server_name"]

--- a/stacks_core/mongo_loader.py
+++ b/stacks_core/mongo_loader.py
@@ -36,7 +36,7 @@ def push_rows(CTX, rows):
     database_name = db_config["database_name"]
     collection_name = db_config["collection_name"]
 
-    server_url = f"mongodb://{username}:{password}@{server_name}"
+    server_url = f"mongodb://{username}:{password}@{server_name}:{port}"
 
     mongoClient= pymongo.MongoClient(server_url)
     mongoDatabase = mongoClient[database_name]

--- a/stacks_core/twitter_streamer.py
+++ b/stacks_core/twitter_streamer.py
@@ -103,7 +103,7 @@ def main(CTX):
     info_logger.info(json.dumps(CTX))
 
     data_logger_config = CTX["data"]
-    data_logger_config["filename"] = os.path.join(DATA_PATH, "tweets")
+    data_logger_config["filename"] = os.path.join(DATA_PATH, "tweets.log")
     data_logger = initialize_data_logger(data_logger_config)
 
     headers = create_headers(CTX["twitter_bearer_token"])


### PR DESCRIPTION
When working with stack2 containers, I found that some variables were hard coded. Also, the mongodb URI was missing the port variable set from the config.json file.

When trying to collect tweets in to a mongodb collection, I found that tweets we're being streamed, but not loaded in to the mongodb collection. after further debugging, I found that in twitter_streamer.py, the twitter data was being saved to a shared DATA directory between the containers, in a file called "tweets". I also noticed that mongo_loader.py was only looking for files ending in ".log" in the shared DATA directory. After renaming tweets to tweets.log, mongo_loader.py finally pushed the tweet data to mongodb.

I've fixed the code below to create a tweets.log file instead of a tweets file in the shared DATA directory.

And finally, I added .DS_Store to the .gitignore file to save my computer from polluting this git repo with unnecessary files and folders :)